### PR TITLE
Update install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -2,3 +2,4 @@
 xcopy %0\..\dyalog-kernel %APPDATA%\jupyter\kernels\dyalog-kernel /Y /I
 xcopy %0\..\dyalog_kernel %APPDATA%\Python\Python36\site-packages\dyalog_kernel /Y /I
 xcopy %0\..\dyalog_kernel %USERPROFILE%\AppData\Local\Continuum\anaconda3\Lib\site-packages\dyalog_kernel /Y /I
+xcopy %0\..\dyalog_kernel %USERPROFILE%\anaconda3\Lib\site-packages\dyalog_kernel /Y /I


### PR DESCRIPTION
Under Windows 10 on a x64 bit machine, the previous .bat "installed" the kernel in such a way that Jupyter Notebook would allow me to create a new notebook with the "Dyalog APL" kernel but then it would fail to connect with the error `C:\Users\xxx\anaconda3\python.exe: No module named dyalog_kernel`.

Copying the folder `dyalog_kernel` into the path I included fixed it for me and the kernel connects successfully.