### PR TITLE
Enable APL font for <code> in Markdown blocks

### DIFF
--- a/dyalog-kernel/kernel.js
+++ b/dyalog-kernel/kernel.js
@@ -10,7 +10,7 @@ define(function(){
             src: local("APL385 Unicode"), url("//cdn.dyalog.com/fonts/Apl385.eot#iefix") format("embedded-opentype"), url("//cdn.dyalog.com/fonts/Apl385.woff") format("woff"), url("//cdn.dyalog.com/fonts/Apl385.ttf") format("truetype"), url("//cdn.dyalog.com/fonts/Apl385.svg#APL385") format("svg");
             /* Chrome < 4, Legacy iOS */
         }
-        .code_cell .CodeMirror,.output_subarea span {font-family:APL385,"DejaVu Sans Mono",monospace !important}
+        code, .code_cell .CodeMirror,.output_subarea span {font-family:APL385,"DejaVu Sans Mono",monospace !important}
         .output_subarea {line-height:1em}
         .cm-apl-asgn{ color:#0000ff; }
         .cm-apl-sqbr{ color:#0000ff; }


### PR DESCRIPTION
Tested and works for inline code `` `code` `` and code block
~~~
```
code
```
~~~