### PR TITLE
Update empty metadata value

### DIFF
--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -114,7 +114,7 @@ class DyalogKernel(Kernel):
             # 'data': {'text/plain': s},
             'data': {'text/html': html_start + html.escape(s, False) + html_end},
             'execution_count': self.execution_count,
-            'metadata': ''
+            'metadata': {},
 
             # 'transient': ''
         }


### PR DESCRIPTION
While having a go with the jupyter-book project, I stumbled upon a funny-looking error when trying to build APL notebooks; the error pointed at a validation problem raised when comparing something to a json schema. The error read `"nbformat.validator.NotebookValidationError: '' is not of type 'object'"` and I traced it back to some schema validation performed by `nbformat`. A wild guess had me check here and turns out changing the "empty metadata" value to an empty dictionary fixes the issue.