### PR TITLE
Highlight comments in user and system commands.

### DIFF
--- a/dyalog-kernel/kernel.js
+++ b/dyalog-kernel/kernel.js
@@ -255,8 +255,11 @@ define(function(){
             blankLine:function(h){h.l++},
             token:function(sm,h){ //sm:stream,h:state
             var sol=sm.sol(),m //sol:start of line? m:regex match object
-            if(sol&&(m=sm.match(/^ *\)(\w+).*/))){h.l++;return!m[1]||scmd.indexOf(m[1].toLowerCase())<0?'apl-err':'apl-scmd'}
-            if(sol&&(m=sm.match(/^ *\].*/))){h.l++;return'apl-ucmd'}
+            if(sol&&(m=sm.match(/^ *\)(\w+).*?(⍝.*)?$/))){
+                if(m[2]){sm.backUp(m[2].length);h.h=im.startState();delete h.h.hdr}else h.l++
+                return!m[1]||scmd.indexOf(m[1].toLowerCase())<0?'apl-err':'apl-scmd'
+            }
+            if(sol&&(m=sm.match(/^ *\].*?(⍝.*)?$/))){if(m[1]){sm.backUp(m[1].length);h.h=im.startState();delete h.h.hdr}else{h.l++}return'apl-ucmd'}
             if(sol){h.h=im.startState();delete h.h.hdr}
             var h1=CM.copyState(im,h.h),t=im.token(sm,h1);if(sm.eol()){h.l++;delete h.h}else{h.h=CM.copyState(im,h1)}
             return t


### PR DESCRIPTION
 - As of now, lines that start with a user/system command are coloured completely without caring about what shows up next, cf. the screenshot below:

![before](https://user-images.githubusercontent.com/5621605/91470075-24e0d000-e88c-11ea-85f0-d47253a54ca5.png)

 - With this partial fix, comments now get displayed properly -- most of the times:

![after](https://user-images.githubusercontent.com/5621605/91470112-33c78280-e88c-11ea-9e37-34e9c55cead2.png)

To better deal with user commands and their arguments, something more clever and thought through might be needed (cf. the `]runtime` command above.)