### PR TITLE
add support for conda environments to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,20 +2,29 @@
 set -e
 
 BASEDIR=$(dirname "$0")
+PYVER="$(python3 --version | sed 's/.*\(3\.[0-9]*\).*/\1/')"
 
-case $(uname) in
-	Darwin)	KERNELDIR=~/Library/Jupyter/kernels ;;
-	Linux)	KERNELDIR=~/.local/share/jupyter/kernels ;;
-	*)	exit 1
-esac
+if [ -z "$CONDA_PREFIX" ]
+then
+	case $(uname) in
+		Darwin)	KERNELDIR=~/Library/Jupyter/kernels ;;
+		Linux)	KERNELDIR=~/.local/share/jupyter/kernels ;;
+		*)	exit 1
+	esac
+	SITEDIR="$(python3 -m site --user-site)"
+	CONDIR="$HOME/anaconda3/lib/python$PYVER/site-packages"
+else
+	KERNELDIR="$CONDA_PREFIX"/share/jupyter/kernels
+	SITEDIR="$CONDA_PREFIX/lib/python$PYVER"
+	CONDIR="$SITEDIR"/site-packages
+fi
+
 mkdir -p "$KERNELDIR"
 cp -r "$BASEDIR"/dyalog-kernel "$KERNELDIR"/
 
-SITEDIR="$(python3 -m site --user-site)"
 mkdir -p "$SITEDIR"
 cp -r "$BASEDIR"/dyalog_kernel "$SITEDIR"/
 
-CONDIR="$HOME/anaconda3/lib/python3.*/site-packages"
 if [ -d "$CONDIR" ] ; then
 	cp -r "$BASEDIR"/dyalog_kernel "$CONDIR"/
 fi


### PR DESCRIPTION
If you run `install.sh` within a Conda environment, it will now install only to
that environment. Behavior outside of Conda environments remains unchanged.
