### PR TITLE
Vega-Lite native support for JupyterLab and DYALOG_NETCORE=1 for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Please see [our wiki](https://github.com/Dyalog/dyalog-jupyter-kernel/wiki).
 ## Do you have any premade notebook documents?
 
 A collection of ready-made notebooks is available [here](https://github.com/Dyalog/dyalog-jupyter-notebooks).
+
+## Support for Jupyterlab native render support for vega-lite
+
+Use :vega-lite tag for correct mime-type.

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -40,7 +40,7 @@ dq = deque()
 
 def debug(s):
     if DYALOGJUPYTERKERNELDEBUG:
-        writeln(s)
+     writeln(s)
 
 
 def writeln(s):
@@ -111,10 +111,11 @@ class DyalogKernel(Kernel):
         self.send_response(self.iopub_socket, 'execute_result', _content)
 
     def out_vl(self, s):
-        s=s.replace('\n', '')
+        s=s.replace('\n      ', '')
         s=s.replace('\r', '')
-        s=s.replace('\\n', '')
-        s=s.replace('\\r', '')
+        s=s.replace('\n', '')
+        #s=s.replace('\\r', '')
+        debug(s)
         _content = {
             'data': {
                 'application/vnd.vegalite.v4+json': json.loads(s)

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -113,7 +113,7 @@ class DyalogKernel(Kernel):
     def out_vl(self, s):
         _content = {
             'data': {
-                'application/vnd.vegalite.v4+json': eval(" ".join(s))
+                'application/vnd.vegalite.v4+json': json.loads(s.replace('\\n', ''))
             },
             'metadata':{},
             'transient':{}
@@ -240,7 +240,7 @@ class DyalogKernel(Kernel):
                     0] + "\\dyalog.exe"
                 CloseKey(dyalogKey)
                 CloseKey(lastKey)
-                self.dyalog_subprocess = subprocess.Popen([dyalogPath, "RIDE_SPAWNED=1", 'RIDE_INIT=SERVE::' + str(
+                self.dyalog_subprocess = subprocess.Popen([dyalogPath, "RIDE_SPAWNED=1","DYALOG_NETCORE=1", 'RIDE_INIT=SERVE::' + str(
                     self._port).strip(), 'LOG_FILE=nul', os.path.dirname(os.path.abspath(__file__)) + '/init.dws'])
             else:
                 # linux, darwin... etc
@@ -390,9 +390,8 @@ class DyalogKernel(Kernel):
                     else:
                         self.define_function(lines)
                         lines = []
-                elif vlmatch:
-                    self.out_vl(lines[1:])
-                    lines = []                
+                elif vlmatch:                
+                    lines=lines[1:]
                 try:
                     # the windows interpreter can only handle ~125 chacaters at a time, so we do one line at a time
                     for line in lines:
@@ -427,7 +426,10 @@ class DyalogKernel(Kernel):
                                         if err:
                                             self.out_error(data_collection)
                                         else:
-                                            self.out_result(data_collection)
+                                            if vlmatch:
+                                                self.out_vl(data_collection)
+                                            else:
+                                                self.out_result(data_collection)
                                         data_collection = ''
                                     err = False
                                 elif pt == 2:

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -102,7 +102,7 @@ class DyalogKernel(Kernel):
 
     def out_html(self, s):
         _content = {
-            # 'output_type': 'display_data',
+            # 'output_type': 'dispslay_data',
             'data': {'text/html': s},
             'execution_count': self.execution_count,
             'metadata': ''
@@ -113,7 +113,7 @@ class DyalogKernel(Kernel):
     def out_vl(self, s):
         _content = {
             'data': {
-                'application/vnd.vegalite.v4+json': json.loads(s.replace('\\n', ''))
+                'application/vnd.vegalite.v4+json': json.loads(s.replace('\n', ''))
             },
             'metadata':{},
             'transient':{}

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -111,9 +111,13 @@ class DyalogKernel(Kernel):
         self.send_response(self.iopub_socket, 'execute_result', _content)
 
     def out_vl(self, s):
+        s=s.replace('\n', '')
+        s=s.replace('\r', '')
+        s=s.replace('\\n', '')
+        s=s.replace('\\r', '')
         _content = {
             'data': {
-                'application/vnd.vegalite.v4+json': json.loads(s.replace('\n', ''))
+                'application/vnd.vegalite.v4+json': json.loads(s)
             },
             'metadata':{},
             'transient':{}
@@ -510,10 +514,9 @@ class DyalogKernel(Kernel):
         if DYALOG_HOST == '127.0.0.1':
             if self.connected:
                 self.ride_send(["Exit", {"code": 0}])
-         #   time.sleep(2)
-         #   if self.dyalog_subprocess:
-         #       self.dyalog_subprocess.kill()
-
+            time.sleep(2)
+            if self.dyalog_subprocess:
+                self.dyalog_subprocess.kill()
         self.dyalogTCP.close()
         self.connected = False
         return {'status': 'ok', 'restart': restart}


### PR DESCRIPTION
`out←'{"$schema": "https://vega.github.io/schema/vega-lite/v5.json","description": "A simple bar chart with embedded data.","data": {"values": [{"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},{"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},{"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}]},"mark": "bar","encoding": {"x": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}},"y": {"field": "b", "type": "quantitative"}}}'`
...
```
:vega-lite
out
```
The first line includes tag `:vega-lite` and the following lines produces the vl-output which a native Vega-Lite renderer shows. 