### PR TITLE
86 kernel cannot connect 4502

### DIFF
--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -24,8 +24,8 @@ DYALOG_HOST = '127.0.0.1'
 DYALOG_PORT = 4502
 TCP_TIMEOUT = 0.1
 
-#_increment for port. To find first available
 _port = DYALOG_PORT
+
 
 # no of sec waiting for initial RIDE handshake. Slower systems should be greater no. of sec, to give dyalog a chance to start
 RIDE_INIT_CONNECT_TIME_OUT = 3  # seconds
@@ -195,24 +195,22 @@ class DyalogKernel(Kernel):
         #from ipykernel import get_connection_file
         #s = get_connection_file()
         # debug("########## " + str(s))
-
+        
         self._port = DYALOG_PORT
-        # lets find first available port, starting from default DYALOG_PORT (:4502)
+        # lets find an available port
         # this makes sense only if Dyalog APL and Jupyter executables are on the same host (localhost)
         if DYALOG_HOST == '127.0.0.1':
-
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             while True:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 try:
-                    sock.bind((str(DYALOG_HOST).strip(), self._port))
-                    # port is available since I can bound
-                    sock.close()
+                    # Trying to bind a random port (0)
+                    sock.bind((str(DYALOG_HOST).strip(), 0))  # Port is available since I can bind
+                    # Get the port number
+                    self._port = sock.getsockname()[1]
                     break
                 except OSError:
-                    # port is in use, try next one
-                    sock.close()
-                    self._port += 1
-
+                    continue
+            sock.close()
         # if Dyalog APL and Jupyter executables are on the same host (localhost) let's start instance of Dyalog
         if DYALOG_HOST == '127.0.0.1':
             if sys.platform.lower().startswith('win'):

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -203,14 +203,14 @@ class DyalogKernel(Kernel):
 
             while True:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                result = sock.connect_ex(
-                    (str(DYALOG_HOST).strip(), self._port))
-                sock.close()
-                #port is available
-                if result != 0:
+                try:
+                    sock.bind((str(DYALOG_HOST).strip(), self._port))
+                    # port is available since I can bound
+                    sock.close()
                     break
-                else:
-                    # try next port
+                except OSError:
+                    # port is in use, try next one
+                    sock.close()
                     self._port += 1
 
         # if Dyalog APL and Jupyter executables are on the same host (localhost) let's start instance of Dyalog


### PR DESCRIPTION
Fix for issue #86 . With this PR, the dyalog-jupyter-kernel attempts to bind to a random port, and if it’s available, that port is used for starting RIDE (I left the DYALOG_PORT as init value if something goes wrong, but it will not start from 4502 and incrementing it for new connections, but just take the first random available). Binding random ports at the system level (by calling sock.bind(...,0)) avoid issue #86 , which is caused by a race condition when starting multiple kernels at the same time. On the other hand, this approach loses the convenience of starting the port assignment from the default 4502.