### PR TITLE
Added one more attempt at finding dyalog on linux

### DIFF
--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -240,7 +240,9 @@ class DyalogKernel(Kernel):
                 dyalog_env['LOG_FILE'] = '/dev/null'
                 dyalog_env['DYALOG_LINEEDITOR_MODE'] = '1'
                 dyalog_env['DYALOGJUPYFOLDER'] = os.path.dirname(os.path.abspath(__file__))
-                if sys.platform.lower() == "darwin":
+                if shutil.which('dyalog'):
+                    dyalog = shutil.which('dyalog')
+                elif sys.platform.lower() == "darwin":
                     for d in sorted(os.listdir('/Applications')):
                         if re.match('^Dyalog-\d+\.\d+\.app$', d):
                             dyalog = '/Applications/' + d + '/Contents/Resources/Dyalog/mapl'
@@ -252,9 +254,7 @@ class DyalogKernel(Kernel):
                             dyalog += sorted(os.listdir(dyalog)
                                              )[-1] + '/' + 'mapl'
                 else:
-                    dyalog = shutil.which('dyalog')
-                    if dyalog == None:
-                        raise FileNotFoundError('Dyalog was not found')
+                    raise FileNotFoundError('Dyalog was not found')
 
                 self.dyalog_subprocess = subprocess.Popen([dyalog, '+s', '-q', 'LOAD='+os.path.dirname(os.path.abspath(__file__))+'/init.aplf'], stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=dyalog_env)
 

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -240,8 +240,8 @@ class DyalogKernel(Kernel):
                 dyalog_env['LOG_FILE'] = '/dev/null'
                 dyalog_env['DYALOG_LINEEDITOR_MODE'] = '1'
                 dyalog_env['DYALOGJUPYFOLDER'] = os.path.dirname(os.path.abspath(__file__))
-                if shutil.which('dyalog'):
-                    dyalog = shutil.which('dyalog')
+                if shutil.which('mapl'):
+                    dyalog = shutil.which('mapl')
                 elif sys.platform.lower() == "darwin":
                     for d in sorted(os.listdir('/Applications')):
                         if re.match('^Dyalog-\d+\.\d+\.app$', d):

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -242,6 +242,8 @@ class DyalogKernel(Kernel):
                 dyalog_env['DYALOGJUPYFOLDER'] = os.path.dirname(os.path.abspath(__file__))
                 if shutil.which('mapl'):
                     dyalog = shutil.which('mapl')
+                elif shutil.which('dyalog'):
+                    dyalog = shutil.which('dyalog')
                 elif sys.platform.lower() == "darwin":
                     for d in sorted(os.listdir('/Applications')):
                         if re.match('^Dyalog-\d+\.\d+\.app$', d):

--- a/dyalog_kernel/kernel.py
+++ b/dyalog_kernel/kernel.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import socket
 import sys
 import time
@@ -243,13 +244,18 @@ class DyalogKernel(Kernel):
                     for d in sorted(os.listdir('/Applications')):
                         if re.match('^Dyalog-\d+\.\d+\.app$', d):
                             dyalog = '/Applications/' + d + '/Contents/Resources/Dyalog/mapl'
-                else:
+                elif os.path.exists('/opt/mdyalog'):
                     for v in sorted(os.listdir('/opt/mdyalog')):
                         if re.match('^\d+\.\d+$', v):
                             dyalog = '/opt/mdyalog/' + v + '/'
                             dyalog += sorted(os.listdir(dyalog))[-1] + '/'
                             dyalog += sorted(os.listdir(dyalog)
                                              )[-1] + '/' + 'mapl'
+                else:
+                    dyalog = shutil.which('dyalog')
+                    if dyalog == None:
+                        raise FileNotFoundError('Dyalog was not found')
+
                 self.dyalog_subprocess = subprocess.Popen([dyalog, '+s', '-q', 'LOAD='+os.path.dirname(os.path.abspath(__file__))+'/init.aplf'], stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=dyalog_env)
 
         Kernel.__init__(self, **kwargs)


### PR DESCRIPTION
I experienced issues having jupyter find dyalog on linux, since python tried searching in `/opt/mdyalog` which doesn't exist on my system. `shutil.which` is the best option I believe, which searches for programs in PATH.